### PR TITLE
feat: reply to mention and dm

### DIFF
--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -45,28 +45,28 @@ export class DiscordService implements OnModuleInit {
 
   onMessageCreate = (msg: Message) => {
     this.processMessage(msg).catch((error) => {
-      console.error('failed to process message error', error);
+      console.error('failed to process message', error);
     });
   };
 
   async processMessage(msg: Message) {
-      if (msg.author.bot) return;
+    if (msg.author.bot) return;
 
-      const isFromTestChannel =
-        msg.channelId ===
-        this.configService.getOrThrow('DISCORD_BOT_TESTING_CHANNEL_ID');
-      const isProduction = this.configService.get('NODE_ENV') === 'production';
+    const isFromTestChannel =
+      msg.channelId ===
+      this.configService.getOrThrow('DISCORD_BOT_TESTING_CHANNEL_ID');
+    const isProduction = this.configService.get('NODE_ENV') === 'production';
 
     if (
       msg.channel instanceof TextChannel &&
       (isFromTestChannel || isProduction)
     ) {
       await this.handleTextChannelMessage(msg);
-      }
+    }
 
     if (msg.channel instanceof DMChannel) {
       await this.handleDm(msg);
-      }
+    }
   }
 
   async sendMessage(channelId: string, embed: EmbedBuilder) {

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -43,11 +43,8 @@ export class DiscordService implements OnModuleInit {
         this.configService.getOrThrow('DISCORD_BOT_TESTING_CHANNEL_ID');
       const isProduction = this.configService.get('NODE_ENV') === 'production';
 
-      if (isFromTestChannel || isProduction) {
-        console.log('hello');
-      if (msg.channel.type === 0) {
+      if (msg.channel.type === 0 && (isFromTestChannel || isProduction)) {
         this.textChannelHandler(msg);
-      }
       }
 
       if (msg.channel.type === 1) {
@@ -80,7 +77,7 @@ export class DiscordService implements OnModuleInit {
   }
 
   async textChannelHandler(msg: Message<boolean>) {
-    const botId = await this.configService.getOrThrow('DISCORD_BOT_USER_ID');
+    const botId = this.configService.getOrThrow('DISCORD_BOT_USER_ID');
     const botWasMentioned = msg.mentions.has(botId);
 
     if (botWasMentioned) {

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -87,15 +87,16 @@ export class DiscordService implements OnModuleInit {
       try {
         await msg.reply('Aye! :)');
       } catch (error) {
-        console.warn('Failed to respond to mention.');
-        console.warn(error);
+        console.error('Failed to respond to mention.', error);
       }
     }
   }
 
   async dmHandler(msg: Message<boolean>) {
-    if (this.configService.get('NODE_ENV') === 'production') {
+    try {
       msg.author.send(`Good to hear from you, ${msg.author.username}.`);
+    } catch (error) {
+      console.error('Failed to respond to dm.', error);
     }
   }
 }

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -35,7 +35,7 @@ export class DiscordService implements OnModuleInit {
       }
     });
 
-    this.client.on('messageCreate', async (msg) => {
+    this.client.on('messageCreate', (msg) => {
       if (msg.author.bot) return;
 
       const isFromTestChannel =
@@ -76,24 +76,22 @@ export class DiscordService implements OnModuleInit {
     );
   }
 
-  async textChannelHandler(msg: Message<boolean>) {
+  textChannelHandler(msg: Message<boolean>) {
     const botId = this.configService.getOrThrow('DISCORD_BOT_USER_ID');
     const botWasMentioned = msg.mentions.has(botId);
 
     if (botWasMentioned) {
-      try {
-        await msg.reply('Aye! :)');
-      } catch (error) {
+      msg.reply('Aye! :)').catch((error) => {
         console.error('Failed to respond to mention.', error);
-      }
+      });
     }
   }
 
-  async dmHandler(msg: Message<boolean>) {
-    try {
-      msg.author.send(`Good to hear from you, ${msg.author.username}.`);
-    } catch (error) {
+  dmHandler(msg: Message<boolean>) {
+    msg.author
+      .send(`Good to hear from you, ${msg.author.username}.`)
+      .catch((error) => {
       console.error('Failed to respond to dm.', error);
-    }
+      });
   }
 }


### PR DESCRIPTION
With this feature, the bot listens to text channel messages and dms. It replies with generic messages to mentions and dms.

To avoid duplicates, message replies are only sent in production. Replies to dms and messages in the testing channel are always sent.