### PR TITLE
refactor: make commands instantiable and injectable

### DIFF
--- a/src/slashCommand/commands/ping.command.ts
+++ b/src/slashCommand/commands/ping.command.ts
@@ -1,15 +1,25 @@
+import { Injectable } from '@nestjs/common';
 import {
   CacheType,
   ChatInputCommandInteraction,
   SlashCommandBuilder,
 } from 'discord.js';
+import { BaseCommand } from '../slashCommand.interface';
 
-export default class PingCommand {
-  public static slashCommandBuilder = new SlashCommandBuilder()
-    .setName('ping')
-    .setDescription('Replies with pong!');
+@Injectable()
+export default class PingCommand implements BaseCommand {
+  public readonly name: string;
+  public readonly slashCommandBuilder: SlashCommandBuilder;
 
-  public static async handleCommand(
+  constructor() {
+    this.name = 'ping';
+
+    this.slashCommandBuilder = new SlashCommandBuilder()
+      .setName(this.name)
+      .setDescription('Replies with pong!');
+  }
+
+  public async handleCommand(
     interaction: ChatInputCommandInteraction<CacheType>,
   ): Promise<void> {
     await interaction.reply('Pong!');

--- a/src/slashCommand/commands/pspsps.command.ts
+++ b/src/slashCommand/commands/pspsps.command.ts
@@ -1,15 +1,25 @@
+import { Injectable } from '@nestjs/common';
 import {
   CacheType,
   ChatInputCommandInteraction,
   SlashCommandBuilder,
 } from 'discord.js';
+import { BaseCommand } from '../slashCommand.interface';
 
-export default class PspspsCommand {
-  public static slashCommandBuilder = new SlashCommandBuilder()
-    .setName('pspsps')
-    .setDescription('A purrrrfect surprise');
+@Injectable()
+export default class PspspsCommand implements BaseCommand {
+  public readonly name: string;
+  public readonly slashCommandBuilder: SlashCommandBuilder;
 
-  public static async handleCommand(
+  constructor() {
+    this.name = 'pspsps';
+
+    this.slashCommandBuilder = new SlashCommandBuilder()
+      .setName(this.name)
+      .setDescription('A purrrrfect surprise');
+  }
+
+  public async handleCommand(
     interaction: ChatInputCommandInteraction<CacheType>,
   ): Promise<void> {
     await interaction.reply('Meow :)');

--- a/src/slashCommand/commands/randomcabin.command.ts
+++ b/src/slashCommand/commands/randomcabin.command.ts
@@ -1,31 +1,44 @@
+import { Injectable } from '@nestjs/common';
 import {
   CacheType,
   ChatInputCommandInteraction,
   SlashCommandBuilder,
 } from 'discord.js';
+import { BaseCommand } from '../slashCommand.interface';
 
-export default class RandomCabinCommand {
-  public static slashCommandBuilder = new SlashCommandBuilder()
-    .setName('randomcabin')
-    .setDescription('Finds a random cabin available at your dates')
-    .setDMPermission(true)
-    .addStringOption((option) =>
-      option
-        .setName('check-in')
-        .setDescription('When do you want to arrive (yyyy-mm-dd)?')
-        .setRequired(true),
-    )
-    .addStringOption((option) =>
-      option
-        .setName('check-out')
-        .setDescription('When do you want to leave (yyyy-mm-dd)?')
-        .setRequired(true),
-    );
+@Injectable()
+export default class RandomCabinCommand implements BaseCommand {
+  public readonly name: string;
+  public readonly slashCommandBuilder: Omit<
+    SlashCommandBuilder,
+    'addSubcommand' | 'addSubcommandGroup'
+  >;
+
+  constructor() {
+    this.name = 'randomcabin';
+
+    this.slashCommandBuilder = new SlashCommandBuilder()
+      .setName(this.name)
+      .setDescription('Finds a random cabin available at your dates')
+      .setDMPermission(true)
+      .addStringOption((option) =>
+        option
+          .setName('check-in')
+          .setDescription('When do you want to arrive (yyyy-mm-dd)?')
+          .setRequired(true),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('check-out')
+          .setDescription('When do you want to leave (yyyy-mm-dd)?')
+          .setRequired(true),
+      );
+  }
 
   // Defer response
   // https://discordjs.guide/interactions/slash-commands.html#editing-responses
 
-  public static async handleCommand(
+  public async handleCommand(
     interaction: ChatInputCommandInteraction<CacheType>,
   ): Promise<void> {
     const checkIn = interaction.options.getString('check-in', true);

--- a/src/slashCommand/slashCommand.interface.ts
+++ b/src/slashCommand/slashCommand.interface.ts
@@ -1,11 +1,10 @@
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export interface BaseCommand {
-  // TODO enforce static method implementation in commands with an abstract class?
-  slashCommandBuilder: Omit<
-    SlashCommandBuilder,
-    'addSubcommand' | 'addSubcommandGroup'
-  >;
+  name: string;
+  slashCommandBuilder:
+    | SlashCommandBuilder
+    | Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>;
 
   handleCommand(arg: ChatInputCommandInteraction): Promise<void>;
 }


### PR DESCRIPTION
Commands are now classes that can be instantiated and have no static methods. They also implement the BaseCommand interface to increase type safety.

For now, automatic loading based on folder/file name has been dropped.
Instead, each new command needs to be added to the constructor of the slash command service to be included in the app.