### PR TITLE
fix: get all cabins despite api limit

### DIFF
--- a/src/cabinUt/cabinUt.api.ts
+++ b/src/cabinUt/cabinUt.api.ts
@@ -1,14 +1,16 @@
 import { CabinUtDetails } from './cabinUt.interface';
 
 export class CabinUtApi {
-  async getCabins(): Promise<{ node: { id: number } }[]> {
+  async getCabins(
+    endCursor: string | null = null,
+  ): Promise<{ node: { id: number } }[]> {
     const query = {
       operationName: 'FindCabins',
       variables: {
         input: {
           pageOptions: {
             limit: 500,
-            afterCursor: null,
+            afterCursor: endCursor,
             orderByDirection: 'DESC',
             orderBy: 'ID',
           },
@@ -29,11 +31,20 @@ export class CabinUtApi {
     };
 
     const body = await this.makeRequest(query);
+    endCursor = body.data.ntb_findCabins.pageInfo.endCursor;
     const {
       data: {
         ntb_findCabins: { edges },
       },
     } = body;
+
+    if (endCursor !== null) {
+      const cabins = await this.getCabins(endCursor);
+      for (const cabin of cabins) {
+        edges.push(cabin);
+      }
+    }
+
     return edges;
   }
   async getCabinDetails(id: number): Promise<CabinUtDetails> {


### PR DESCRIPTION
The previous version of the getCabins method was limited to 500 elements, as higher numbers were rejected by the api.
To get all elements, the method is now called recursively.
Each new call receives the endCursor of the previous call and applies it as value for afterCursor in the query.