### PR TITLE
Feature randomcabin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ The bot replies to dms and mentions in text channels with a generic message.
 ### /randomcabin
 
 ```
+/randomcabin
 /randomcabin check-in: yyyy-mm-dd check-out: yyyy-mm-dd
 ```
 
-_This feature is still work in progress._
-
-Want to go on a cabin trip but don't know where to go? Tell the bot when you'd like to go and it finds a random cabin for you that is available at the desired dates. The command is available in text channels and dms.
+Want to go on a cabin trip but don't know where to go? Tell the bot when you'd like to go and it finds a random cabin for you that is available at the desired dates. If you omit the dates, you will receive any random cabin instead. Be aware, that we cannot check the availability of all cabins (yet), so providing dates limits the pool of potential cabins. To protect your privacy, Turbo's response is always private - nobody will know that you asked...
 
 ## :red_circle: Other features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
         "ts-loader": "^9.2.3",
         "ts-node": "^10.0.0",
         "tsconfig-paths": "4.1.0",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "yup": "^0.32.11"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -721,6 +722,18 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.10"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2092,6 +2105,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.189",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.189.tgz",
+      "integrity": "sha512-kb9/98N6X8gyME9Cf7YaqIMvYGnBSWqEci6tiettE6iJWH1XdJz/PO8LB0GtLCG7x8dU3KWhZT+lA1a35127tA==",
       "dev": true
     },
     "node_modules/@types/mime": {
@@ -6622,6 +6641,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6909,6 +6934,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "node_modules/nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
       "dev": true
     },
     "node_modules/natural-compare": {
@@ -7659,6 +7690,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==",
+      "dev": true
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7875,6 +7912,12 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+      "dev": true
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -8821,6 +8864,12 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
@@ -9695,6 +9744,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     }
   },
   "dependencies": {
@@ -10200,6 +10267,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.10"
       }
     },
     "@babel/template": {
@@ -11286,6 +11362,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.189",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.189.tgz",
+      "integrity": "sha512-kb9/98N6X8gyME9Cf7YaqIMvYGnBSWqEci6tiettE6iJWH1XdJz/PO8LB0GtLCG7x8dU3KWhZT+lA1a35127tA==",
       "dev": true
     },
     "@types/mime": {
@@ -14709,6 +14791,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -14928,6 +15016,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
       "dev": true
     },
     "natural-compare": {
@@ -15465,6 +15559,12 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -15631,6 +15731,12 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+      "dev": true
     },
     "regexpp": {
       "version": "3.2.0",
@@ -16322,6 +16428,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
@@ -16935,6 +17047,21 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "tsconfig-paths": "4.1.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "yup": "^0.32.11"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/cabin/cabin.service.ts
+++ b/src/cabin/cabin.service.ts
@@ -1,13 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { CabinSummary } from 'src/cabinDatabase/cabinDatabase.interface';
 import { CabinDatabaseService } from 'src/cabinDatabase/cabinDatabase.service';
-import {
-  BookingDates,
-  BookingDatesSchema,
-} from 'src/slashCommand/commands/randomcabin.utils';
+import { BookingDates } from 'src/slashCommand/commands/randomcabin.utils';
 import { VisbookService } from 'src/visbook/visbook.service';
 import { hasExceededTimeLimit } from './cabin.utils';
-
 
 @Injectable()
 export class CabinService {

--- a/src/cabin/cabin.service.ts
+++ b/src/cabin/cabin.service.ts
@@ -1,8 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { CabinSummary } from 'src/cabinDatabase/cabinDatabase.interface';
 import { CabinDatabaseService } from 'src/cabinDatabase/cabinDatabase.service';
+import {
+  BookingDates,
+  BookingDatesSchema,
+} from 'src/slashCommand/commands/randomcabin.utils';
 import { VisbookService } from 'src/visbook/visbook.service';
-import { dateIsValid, hasExceededTimeLimit } from './cabin.utils';
+import { hasExceededTimeLimit } from './cabin.utils';
+
 
 @Injectable()
 export class CabinService {
@@ -17,15 +22,8 @@ export class CabinService {
   }
 
   async getRandomAvailableCabin(
-    checkIn: string,
-    checkOut: string,
+    bookingDates: BookingDates,
   ): Promise<CabinSummary | null> {
-    // TODO move validation to randomcabin command
-    if (!dateIsValid(checkIn) || !dateIsValid(checkOut)) {
-      console.log('invalid date(s)');
-      return null;
-    }
-
     const ONE_MIN_IN_MILLISECONDS = 1 * 60 * 1000;
     const startTime = Date.now();
 
@@ -35,15 +33,13 @@ export class CabinService {
 
       const cabinIsBookable = await this.visbookService.isBookingEnabled(
         cabin.visbookId,
-        checkIn,
-        checkOut,
+        bookingDates,
       );
       if (!cabinIsBookable) continue;
 
       const cabinIsAvailable = await this.visbookService.isCabinAvailable(
         cabin.visbookId,
-        checkIn,
-        checkOut,
+        bookingDates,
       );
       if (cabinIsAvailable) return cabin;
     } while (

--- a/src/cabin/cabin.service.ts
+++ b/src/cabin/cabin.service.ts
@@ -11,7 +11,6 @@ export class CabinService {
     private readonly cabinDatabaseService: CabinDatabaseService,
   ) {}
 
-
   async getRandomCabin(): Promise<CabinSummary | null> {
     const cabins = await this.cabinDatabaseService.getRandomCabin();
     return cabins;

--- a/src/cabin/cabin.utils.test.ts
+++ b/src/cabin/cabin.utils.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { dateIsValid, hasExceededTimeLimit } from './cabin.utils';
+import { hasExceededTimeLimit } from './cabin.utils';
 
 describe('Checking time limit', () => {
   it('returns false if time limit is not passed', () => {
@@ -8,17 +8,5 @@ describe('Checking time limit', () => {
   });
   it('returns true if time limit is passed', () => {
     assert.deepEqual(hasExceededTimeLimit(1000, 2000, 5), true);
-  });
-});
-
-describe('Validating input as date string yyyy-mm-dd', () => {
-  it('returns true for valid date string', () => {
-    assert.deepEqual(dateIsValid('2022-10-16'), true);
-  });
-  it('returns false for invalid date string', () => {
-    assert.deepEqual(dateIsValid('2022-10-66'), false);
-  });
-  it('returns false for any string', () => {
-    assert.deepEqual(dateIsValid('hello'), false);
   });
 });

--- a/src/cabin/cabin.utils.ts
+++ b/src/cabin/cabin.utils.ts
@@ -9,20 +9,3 @@ export function hasExceededTimeLimit(
   }
   return false;
 }
-
-export function dateIsValid(dateString: string): boolean {
-  const regex = /^\d{4}-\d{2}-\d{2}$/;
-
-  if (dateString.match(regex) === null) {
-    return false;
-  }
-
-  const date = new Date(dateString);
-  const timestamp = date.getTime();
-
-  if (typeof timestamp !== 'number' || Number.isNaN(timestamp)) {
-    return false;
-  }
-
-  return date.toISOString().startsWith(dateString);
-}

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -167,14 +167,18 @@ export class DiscordService implements OnModuleInit {
     await this.registerGuildCommands([]);
   }
 
-  async sendMessage(channelId: string, embed: EmbedBuilder) {
+  async sendMessage(
+    channelId: string,
+    messageContent: string,
+    embed: EmbedBuilder,
+  ) {
     const channel = await this.client.channels.fetch(channelId);
     if (!channel || !channel.isTextBased()) {
       console.log('channel not found');
       return false;
     }
 
-    await channel.send({ embeds: [embed] });
+    await channel.send({ content: messageContent, embeds: [embed] });
   }
 
   async getChannels() {

--- a/src/slashCommand/commands/randomcabin.command.ts
+++ b/src/slashCommand/commands/randomcabin.command.ts
@@ -2,8 +2,12 @@ import { Injectable } from '@nestjs/common';
 import {
   CacheType,
   ChatInputCommandInteraction,
+  EmbedBuilder,
   SlashCommandBuilder,
 } from 'discord.js';
+import { convert } from 'html-to-text';
+import { CabinService } from 'src/cabin/cabin.service';
+import { CabinSummary } from 'src/cabinDatabase/cabinDatabase.interface';
 import { BaseCommand } from '../slashCommand.interface';
 
 @Injectable()
@@ -14,35 +18,103 @@ export default class RandomCabinCommand implements BaseCommand {
     'addSubcommand' | 'addSubcommandGroup'
   >;
 
-  constructor() {
+  constructor(private readonly cabinService: CabinService) {
     this.name = 'randomcabin';
 
     this.slashCommandBuilder = new SlashCommandBuilder()
       .setName(this.name)
-      .setDescription('Finds a random cabin available at your dates')
+      .setDescription(
+        'Get a random cabin. Optional: Provide dates to make sure it is available.',
+      )
       .setDMPermission(true)
       .addStringOption((option) =>
         option
           .setName('check-in')
           .setDescription('When do you want to arrive (yyyy-mm-dd)?')
-          .setRequired(true),
+          .setRequired(false),
       )
       .addStringOption((option) =>
         option
           .setName('check-out')
           .setDescription('When do you want to leave (yyyy-mm-dd)?')
-          .setRequired(true),
+          .setRequired(false),
       );
   }
 
-  // Defer response
-  // https://discordjs.guide/interactions/slash-commands.html#editing-responses
+  onModuleInit() {}
 
   public async handleCommand(
     interaction: ChatInputCommandInteraction<CacheType>,
   ): Promise<void> {
-    const checkIn = interaction.options.getString('check-in', true);
-    const checkOut = interaction.options.getString('check-out', true);
-    await interaction.reply('Not quite there yet, but working on it!');
+    await interaction.deferReply({ ephemeral: true });
+    const checkIn = interaction.options.getString('check-in', false);
+    const checkOut = interaction.options.getString('check-out', false);
+
+    // TODO Validate date here!?
+
+    if (checkIn === null || checkOut === null) {
+      await this.handleRandomCabinWithoutDates(interaction);
+    } else {
+      await this.handleRandomCabinWithDates(interaction, checkIn, checkOut);
+    }
+  }
+
+  private async handleRandomCabinWithoutDates(
+    interaction: ChatInputCommandInteraction<CacheType>,
+  ): Promise<void> {
+    const cabin = await this.cabinService.getRandomCabin();
+
+    if (cabin === null) {
+      await interaction.editReply(
+        `I'm sorry, but looks like I could not find any cabin for you. :crying_cat_face:`,
+      );
+    } else {
+      this.editReplyWithCabin(interaction, cabin);
+    }
+  }
+
+  private async handleRandomCabinWithDates(
+    interaction: ChatInputCommandInteraction<CacheType>,
+    checkIn: string,
+    checkOut: string,
+  ): Promise<void> {
+    const cabin = await this.cabinService.getRandomAvailableCabin(
+      checkIn,
+      checkOut,
+    );
+
+    if (cabin === null) {
+      await interaction.editReply(
+        `I'm sorry, but looks like I could not find any cabin for you. :crying_cat_face:`,
+      );
+    } else {
+      this.editReplyWithCabin(interaction, cabin);
+    }
+  }
+
+  // TODO can we reuse the method from bot service or write one that can be used by both modules? Maybe in cabin service or cabin database service?
+  private async buildCabinEmbed(cabin: CabinSummary): Promise<EmbedBuilder> {
+    const text = convert(cabin.description);
+    const imageUrl = `https://res.cloudinary.com/ntb/image/upload/w_1280,q_80/v1/${cabin.media[0].uri}`;
+
+    const embed = new EmbedBuilder()
+      .setColor(0xd82d20)
+      .setTitle(cabin.name)
+      .setURL(`https://ut.no/hytte/${cabin.utId}`)
+      .setDescription(text.split('\n')[0] + '...')
+      .setImage(imageUrl);
+
+    return embed;
+  }
+
+  private async editReplyWithCabin(
+    interaction: ChatInputCommandInteraction<CacheType>,
+    cabin: CabinSummary,
+  ): Promise<void> {
+    const embed = await this.buildCabinEmbed(cabin);
+    await interaction.editReply({
+      content: `How about going to ${cabin.name}? :heart_eyes_cat:`,
+      embeds: [embed],
+    });
   }
 }

--- a/src/slashCommand/commands/randomcabin.command.ts
+++ b/src/slashCommand/commands/randomcabin.command.ts
@@ -113,12 +113,26 @@ export default class RandomCabinCommand implements BaseCommand {
     return embed;
   }
 
+  private async buildBookingEmbed({
+    bookingUrl,
+    name,
+  }: CabinSummary): Promise<EmbedBuilder> {
+    const title = `:point_right: Book ${name} now!`;
+    const embed = new EmbedBuilder()
+      .setColor(0xd82d20)
+      .setTitle(title)
+      .setURL(bookingUrl);
+
+    return embed;
+  }
+
   private async editReplyWithCabin(
     interaction: ChatInputCommandInteraction<CacheType>,
     cabin: CabinSummary,
     bookingDates?: BookingDates,
   ): Promise<void> {
-    const messageEmbed = await this.buildCabinEmbed(cabin);
+    const cabinEmbed = await this.buildCabinEmbed(cabin);
+    const bookingEmbed = await this.buildBookingEmbed(cabin);
 
     const dateOptions: Intl.DateTimeFormatOptions = {
       weekday: 'long',
@@ -142,7 +156,7 @@ export default class RandomCabinCommand implements BaseCommand {
 
     await interaction.editReply({
       content: messageContent,
-      embeds: [messageEmbed],
+      embeds: [cabinEmbed, bookingEmbed],
     });
   }
 }

--- a/src/slashCommand/commands/randomcabin.command.ts
+++ b/src/slashCommand/commands/randomcabin.command.ts
@@ -41,8 +41,6 @@ export default class RandomCabinCommand implements BaseCommand {
       );
   }
 
-  onModuleInit() {}
-
   public async handleCommand(
     interaction: ChatInputCommandInteraction<CacheType>,
   ): Promise<void> {

--- a/src/slashCommand/commands/randomcabin.command.ts
+++ b/src/slashCommand/commands/randomcabin.command.ts
@@ -80,7 +80,7 @@ export default class RandomCabinCommand implements BaseCommand {
       checkOut,
     );
 
-    if (bookingDates === undefined) {
+    if (!bookingDates) {
       await interaction.editReply(
         `Looks like there's something wrong with your dates.`,
       );

--- a/src/slashCommand/commands/randomcabin.utils.ts
+++ b/src/slashCommand/commands/randomcabin.utils.ts
@@ -3,29 +3,25 @@ import { startOfDay, addDays } from 'date-fns';
 
 export type BookingDates = { checkIn: Date; checkOut: Date };
 
+const schema = object({
+  checkIn: date()
+    .required('Check-in is required')
+    .min(startOfDay(new Date()), 'Check-in cannot be in the past'),
+  checkOut: date()
+    .when('checkIn', (checkIn, schema) => {
+      if (checkIn) {
+        return schema.min(
+          addDays(checkIn, 1),
+          'Check-out must be after check-in',
+        );
+      } else {
+        return schema;
+      }
+    })
+    .required('Check-out is required'),
+});
+
 export class BookingDatesSchema {
-  private schema;
-
-  constructor() {
-    this.schema = object({
-      checkIn: date()
-        .required('Check-in is required')
-        .min(startOfDay(new Date()), 'Check-in cannot be in the past'),
-      checkOut: date()
-        .when('checkIn', (checkIn, schema) => {
-          if (checkIn) {
-            return schema.min(
-              addDays(checkIn, 1),
-              'Check-out must be after check-in',
-            );
-          } else {
-            return schema;
-          }
-        })
-        .required('Check-out is required'),
-    });
-  }
-
   public async validate(
     checkIn: string | null,
     checkOut: string | null,
@@ -36,7 +32,7 @@ export class BookingDatesSchema {
     };
 
     try {
-      return await this.schema.validate(data, {
+      return await schema.validate(data, {
         abortEarly: false,
       });
     } catch (e) {

--- a/src/slashCommand/commands/randomcabin.utils.ts
+++ b/src/slashCommand/commands/randomcabin.utils.ts
@@ -41,7 +41,11 @@ export class BookingDatesSchema {
       });
     } catch (e) {
       if (e instanceof ValidationError || e instanceof TypeError) {
-        console.warn(e.message);
+        console.log(
+          `timestamp=${Date.now().toString()}`,
+          'origin="booking date validation"',
+          `message="${e.message}"`,
+        );
         return;
       }
       throw e;

--- a/src/slashCommand/commands/randomcabin.utils.ts
+++ b/src/slashCommand/commands/randomcabin.utils.ts
@@ -1,4 +1,4 @@
-import yup from 'yup';
+import { object, date, ValidationError } from 'yup';
 import { startOfDay, addDays } from 'date-fns';
 
 export type BookingDates = { checkIn: Date; checkOut: Date };
@@ -7,13 +7,11 @@ export class BookingDatesSchema {
   private schema;
 
   constructor() {
-    this.schema = yup.object({
-      checkIn: yup
-        .date()
+    this.schema = object({
+      checkIn: date()
         .required('Check-in is required')
         .min(startOfDay(new Date()), 'Check-in cannot be in the past'),
-      checkOut: yup
-        .date()
+      checkOut: date()
         .when('checkIn', (checkIn, schema) => {
           if (checkIn) {
             return schema.min(
@@ -42,7 +40,7 @@ export class BookingDatesSchema {
         abortEarly: false,
       });
     } catch (e) {
-      if (e instanceof yup.ValidationError) {
+      if (e instanceof ValidationError) {
         console.warn(e.message);
         return;
       }

--- a/src/slashCommand/commands/randomcabin.utils.ts
+++ b/src/slashCommand/commands/randomcabin.utils.ts
@@ -40,7 +40,7 @@ export class BookingDatesSchema {
         abortEarly: false,
       });
     } catch (e) {
-      if (e instanceof ValidationError) {
+      if (e instanceof ValidationError || e instanceof TypeError) {
         console.warn(e.message);
         return;
       }

--- a/src/slashCommand/commands/randomcabin.utils.ts
+++ b/src/slashCommand/commands/randomcabin.utils.ts
@@ -1,0 +1,52 @@
+import yup from 'yup';
+import { startOfDay, addDays } from 'date-fns';
+
+export type BookingDates = { checkIn: Date; checkOut: Date };
+
+export class BookingDatesSchema {
+  private schema;
+
+  constructor() {
+    this.schema = yup.object({
+      checkIn: yup
+        .date()
+        .required('Check-in is required')
+        .min(startOfDay(new Date()), 'Check-in cannot be in the past'),
+      checkOut: yup
+        .date()
+        .when('checkIn', (checkIn, schema) => {
+          if (checkIn) {
+            return schema.min(
+              addDays(checkIn, 1),
+              'Check-out must be after check-in',
+            );
+          } else {
+            return schema;
+          }
+        })
+        .required('Check-out is required'),
+    });
+  }
+
+  public async validate(
+    checkIn: string | null,
+    checkOut: string | null,
+  ): Promise<BookingDates | undefined> {
+    const data = {
+      checkIn: checkIn,
+      checkOut: checkOut,
+    };
+
+    try {
+      return await this.schema.validate(data, {
+        abortEarly: false,
+      });
+    } catch (e) {
+      if (e instanceof yup.ValidationError) {
+        console.warn(e.message);
+        return;
+      }
+      throw e;
+    }
+  }
+}

--- a/src/slashCommand/slashCommand.module.ts
+++ b/src/slashCommand/slashCommand.module.ts
@@ -1,10 +1,11 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { CabinModule } from 'src/cabin/cabin.module';
 import { DiscordModule } from 'src/discord/discord.module';
 import { SlashCommandService } from './slashCommand.service';
 
 @Module({
-  imports: [ConfigModule, forwardRef(() => DiscordModule)],
+  imports: [ConfigModule, forwardRef(() => DiscordModule), CabinModule],
   providers: [SlashCommandService],
   exports: [SlashCommandService],
 })

--- a/src/slashCommand/slashCommand.module.ts
+++ b/src/slashCommand/slashCommand.module.ts
@@ -1,11 +1,17 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { BotModule } from 'src/bot/bot.module';
 import { CabinModule } from 'src/cabin/cabin.module';
 import { DiscordModule } from 'src/discord/discord.module';
 import { SlashCommandService } from './slashCommand.service';
 
 @Module({
-  imports: [ConfigModule, forwardRef(() => DiscordModule), CabinModule],
+  imports: [
+    ConfigModule,
+    forwardRef(() => BotModule),
+    CabinModule,
+    forwardRef(() => DiscordModule),
+  ],
   providers: [SlashCommandService],
   exports: [SlashCommandService],
 })

--- a/src/slashCommand/slashCommand.service.ts
+++ b/src/slashCommand/slashCommand.service.ts
@@ -3,6 +3,7 @@ import {
   Interaction,
   RESTPostAPIApplicationCommandsJSONBody,
 } from 'discord.js';
+import { CabinService } from 'src/cabin/cabin.service';
 import { DiscordService } from 'src/discord/discord.service';
 import PingCommand from './commands/ping.command';
 import PspspsCommand from './commands/pspsps.command';
@@ -16,11 +17,12 @@ export class SlashCommandService implements OnModuleInit {
   constructor(
     @Inject(forwardRef(() => DiscordService))
     private readonly discordService: DiscordService,
+    private readonly cabinService: CabinService,
   ) {
     this.slashCommands = [
       new PingCommand(),
       new PspspsCommand(),
-      new RandomCabinCommand(),
+      new RandomCabinCommand(this.cabinService),
     ];
   }
 

--- a/src/visbook/visbook.api.ts
+++ b/src/visbook/visbook.api.ts
@@ -10,8 +10,13 @@ export class VisbookApi {
     cabinVisbookId: number,
     bookingDates: BookingDates,
   ): Promise<AccommodationAvailability> {
-    const checkIn = bookingDates.checkIn.toISOString().split('T')[0];
-    const checkOut = bookingDates.checkOut.toISOString().split('T')[0];
+    const formatAsYYYYMMDD = (date: Date) => {
+      // Target format is yyyy-mm-dd
+      return date.toISOString().split('T')[0];
+    };
+
+    const checkIn = formatAsYYYYMMDD(bookingDates.checkIn);
+    const checkOut = formatAsYYYYMMDD(bookingDates.checkOut);
     const request = `/${cabinVisbookId}/webproducts/${checkIn}/${checkOut}`;
     return await this.makeRequest(request);
   }

--- a/src/visbook/visbook.api.ts
+++ b/src/visbook/visbook.api.ts
@@ -1,4 +1,5 @@
 import { BookingDates } from 'src/slashCommand/commands/randomcabin.utils';
+import { formatAsYYYYMMDD } from './visbook.utils';
 import { AccommodationAvailability } from './visbook.interface';
 
 /*
@@ -10,11 +11,6 @@ export class VisbookApi {
     cabinVisbookId: number,
     bookingDates: BookingDates,
   ): Promise<AccommodationAvailability> {
-    const formatAsYYYYMMDD = (date: Date) => {
-      // Target format is yyyy-mm-dd
-      return date.toISOString().split('T')[0];
-    };
-
     const checkIn = formatAsYYYYMMDD(bookingDates.checkIn);
     const checkOut = formatAsYYYYMMDD(bookingDates.checkOut);
     const request = `/${cabinVisbookId}/webproducts/${checkIn}/${checkOut}`;

--- a/src/visbook/visbook.api.ts
+++ b/src/visbook/visbook.api.ts
@@ -1,3 +1,4 @@
+import { BookingDates } from 'src/slashCommand/commands/randomcabin.utils';
 import { AccommodationAvailability } from './visbook.interface';
 
 /*
@@ -7,9 +8,10 @@ Visbook API docs: https://ws.visbook.com/8/docs/index.html
 export class VisbookApi {
   async getAccommodationAvailability(
     cabinVisbookId: number,
-    checkIn: string,
-    checkOut: string,
+    bookingDates: BookingDates,
   ): Promise<AccommodationAvailability> {
+    const checkIn = bookingDates.checkIn.toISOString().split('T')[0];
+    const checkOut = bookingDates.checkOut.toISOString().split('T')[0];
     const request = `/${cabinVisbookId}/webproducts/${checkIn}/${checkOut}`;
     return await this.makeRequest(request);
   }

--- a/src/visbook/visbook.service.ts
+++ b/src/visbook/visbook.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { BookingDates } from 'src/slashCommand/commands/randomcabin.utils';
 import { VisbookApi } from './visbook.api';
 
 @Injectable()
@@ -9,13 +10,11 @@ export class VisbookService {
 
   async isCabinAvailable(
     cabinVisbookId: number,
-    checkIn: string,
-    checkOut: string,
+    bookingDates: BookingDates,
   ): Promise<boolean> {
     const visbookResponse = await this.visbookApi.getAccommodationAvailability(
       cabinVisbookId,
-      checkIn,
-      checkOut,
+      bookingDates,
     );
 
     const accommodations = visbookResponse.accommodations;
@@ -34,14 +33,12 @@ export class VisbookService {
   // TODO This is a suggestion to prevent exceptions getting in the way of finding a random available cabin
   async isBookingEnabled(
     cabinVisbookId: number,
-    checkIn: string,
-    checkOut: string,
+    bookingDates: BookingDates,
   ): Promise<boolean> {
     try {
       await this.visbookApi.getAccommodationAvailability(
         cabinVisbookId,
-        checkIn,
-        checkOut,
+        bookingDates,
       );
     } catch (error) {
       this.logger.warn(

--- a/src/visbook/visbook.service.ts
+++ b/src/visbook/visbook.service.ts
@@ -44,8 +44,8 @@ export class VisbookService {
         checkOut,
       );
     } catch (error) {
-      this.logger.error(
-        'getAccommodationAvailability failed with error',
+      this.logger.warn(
+        'getAccommodationAvailability failed with error via isBookingEnabled',
         error,
       );
       return false;

--- a/src/visbook/visbook.utils.ts
+++ b/src/visbook/visbook.utils.ts
@@ -1,0 +1,4 @@
+export function formatAsYYYYMMDD(date: Date) {
+  // Target format is yyyy-mm-dd
+  return date.toISOString().split('T')[0];
+}


### PR DESCRIPTION
This feature implements the randomcabin command with two basic options for user interaction (closes #13):
```
/randomcabin
/randomcabin check-in check-out
```
The user receives an ephemeral (=deferred), private response with either any random cabin or a random cabin that is available during the provided dates. The latter limits the pool of potential cabins to those where we can check the availability via the visbook api.

User provided dates are converted to actual dates using yup and considering several validation rules (correct dates and correct range, i.e. not in the past, check-in before check-out).
Subsequent functions are changed to accept dates instead of pure strings (closes #12).

Edit: Building cabin embed and booking embed are now reusable methods of bot service. Discord service's send message method was refactored to be able to include messages in addition to embeds.

This PR fixes an unreported bug that cabin links in daily cabin post do not point to the right id (internal id was used instead of UT id, was introduced when changing the daily cabin method to using our database and no longer fetching from UT directly).

<img width="622" alt="image" src="https://user-images.githubusercontent.com/107993130/202433024-caf84bd3-367d-4d50-b6fe-52ad818cc986.png">
