### PR TITLE
Fix: do not reply to replies to own messages

### DIFF
--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -85,6 +85,12 @@ export class DiscordService implements OnModuleInit {
   async processMessage(msg: Message) {
     if (msg.author.bot) return;
 
+    const REPLY = 19;
+    if (msg.type === REPLY) {
+      const referencedMessage = await msg.fetchReference();
+      if (referencedMessage.author.id === this.botId) return;
+    }
+
     const isFromTestChannel = msg.channelId === this.testingChannelId;
     const isProduction = this.environment === 'production';
 


### PR DESCRIPTION
With this fix, Turbo will no longer reply to messages that are replies to his own messages (closes #9).