### PR TITLE
Feature: Subscribe to new cabins and activities

### DIFF
--- a/docs/dev-guide/modules.md
+++ b/docs/dev-guide/modules.md
@@ -15,8 +15,9 @@ CabinModule --> VisbookModule
 CabinDatabaseModule --> CabinUtModule
 CabinUtModule --> VisbookModule
 DiscordModule --> SlashCommandModule
-EmbedModule
 SlashCommandModule --> CabinModule
 SlashCommandModule --> ChatCommandModule
 SlashCommandModule --> EmbedModule
+SlashCommandModule --> SubscriptionModule
+SubscriptionModule --> DbModule
 ```

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,10 +52,11 @@ model subscription_topics {
 
 model subscriptions {
   id             BigInt    @id @default(autoincrement())
-  subscriberId   BigInt?
-  subscriberType String?
+  subscriberId   String
+  subscriberType String
   topic          String?
   createdAt      DateTime? @default(now()) @db.Timestamptz(6)
-  updatedAt      DateTime? @db.Timestamptz(6)
+  updatedAt      DateTime? @default(now()) @db.Timestamptz(6)
   notifiedAt     DateTime? @db.Timestamptz(6)
+  type           String
 }

--- a/src/slashCommand/commands/subscribe.command.ts
+++ b/src/slashCommand/commands/subscribe.command.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@nestjs/common';
+import {
+  CacheType,
+  ChatInputCommandInteraction,
+  RESTPostAPIApplicationCommandsJSONBody,
+  SlashCommandBuilder,
+} from 'discord.js';
+import { SubscriptionService } from 'src/subscription/subscription.service';
+import { BaseCommand } from '../slashCommand.interface';
+
+@Injectable()
+export default class SubscribeCommand implements BaseCommand {
+  public readonly name: string;
+  public readonly slashCommandBuilder: RESTPostAPIApplicationCommandsJSONBody;
+
+  constructor(private readonly subscriptionService: SubscriptionService) {
+    this.name = 'subscribe';
+
+    this.slashCommandBuilder = new SlashCommandBuilder()
+      .setName(this.name)
+      .setDescription('Subscribe for notifications.')
+
+      .addSubcommandGroup((group) =>
+        group
+          .setName('channel')
+          .setDescription('Subscribe the current channel.')
+          .addSubcommand((subcommand) =>
+            subcommand
+              .setName('activities')
+              .setDescription(
+                `Subscribe the current channel to new activities.`,
+              )
+              .addStringOption((option) =>
+                option
+                  .setName('topic')
+                  .setDescription(
+                    `Choose your topic of interest, for example "klatring"`,
+                  )
+                  .setRequired(true),
+              ),
+          ),
+      )
+
+      .addSubcommand((subcommand) =>
+        subcommand
+          .setName('activities')
+          .setDescription(`Get notified about new activities.`)
+          .addStringOption((option) =>
+            option
+              .setName('topic')
+              .setDescription(
+                `Choose your topic of interest, for example "klatring"`,
+              )
+              .setRequired(true),
+          ),
+      )
+
+      .addSubcommand((subcommand) =>
+        subcommand
+          .setName('cabins')
+          .setDescription(`Get notified about new cabins.`),
+      )
+      .toJSON();
+  }
+
+  public async handleCommand(
+    interaction: ChatInputCommandInteraction<CacheType>,
+  ): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+    const isAdded = await this.addSubscription(interaction);
+    this.editReply(interaction, isAdded);
+  }
+
+  private async addSubscription(
+    interaction: ChatInputCommandInteraction<CacheType>,
+  ): Promise<boolean> {
+    const subscriber = this.getSubscriber(interaction);
+    const subscription = {
+      subscriberId: subscriber.id,
+      subscriberType: subscriber.type,
+      type: interaction.options.getSubcommand(),
+      topic: interaction.options.getString('topic', false),
+    };
+
+    return await this.subscriptionService.add(subscription);
+  }
+
+  private getSubscriber(interaction: ChatInputCommandInteraction<CacheType>) {
+    const type = interaction.options.getSubcommandGroup();
+    if (type === null) {
+      return { id: interaction.user.id, type: 'user' };
+    }
+    return { id: interaction.channelId, type: type };
+  }
+
+  private async editReply(
+    interaction: ChatInputCommandInteraction<CacheType>,
+    isAdded: boolean,
+  ): Promise<void> {
+    if (isAdded) {
+      const subcommand = interaction.options.getSubcommand();
+
+      let description;
+      if (subcommand === 'cabins') {
+        description = `new DNT cabins`;
+      }
+
+      if (subcommand === 'activities') {
+        const topic = interaction.options.getString('topic', false);
+        description = `new activities about "${topic}"`;
+      }
+
+      const subscriber = this.getSubscriber(interaction);
+      let to;
+      if (subscriber.type === 'user') {
+        to = `You are`;
+      }
+      if (subscriber.type === 'channel') {
+        to = `This channel is`;
+      }
+
+      const messageContent = `${to} now subscribed to ${description} and will receive notifications once daily.
+This feature is under development, please contact an administrator if you want to unsubscribe.`;
+
+      await interaction.editReply({ content: messageContent });
+    } else {
+      const messageContent = `Failed to subscribe, please try again later.`;
+      await interaction.editReply({ content: messageContent });
+    }
+  }
+}

--- a/src/slashCommand/slashCommand.module.ts
+++ b/src/slashCommand/slashCommand.module.ts
@@ -3,10 +3,17 @@ import { ConfigModule } from '@nestjs/config';
 import { CabinModule } from 'src/cabin/cabin.module';
 import { ChatCommandModule } from 'src/chatCommand/chatCommand.module';
 import { EmbedModule } from 'src/embed/embed.module';
+import { SubscriptionModule } from 'src/subscription/subscription.module';
 import { SlashCommandService } from './slashCommand.service';
 
 @Module({
-  imports: [ConfigModule, CabinModule, EmbedModule, ChatCommandModule],
+  imports: [
+    ConfigModule,
+    CabinModule,
+    EmbedModule,
+    ChatCommandModule,
+    SubscriptionModule,
+  ],
   providers: [SlashCommandService],
   exports: [SlashCommandService],
 })

--- a/src/slashCommand/slashCommand.service.ts
+++ b/src/slashCommand/slashCommand.service.ts
@@ -6,9 +6,11 @@ import {
 import { CabinService } from 'src/cabin/cabin.service';
 import { ChatCommandService } from 'src/chatCommand/chatCommand.service';
 import { EmbedService } from 'src/embed/embed.service';
+import { SubscriptionService } from 'src/subscription/subscription.service';
 import PingCommand from './commands/ping.command';
 import PspspsCommand from './commands/pspsps.command';
 import RandomCabinCommand from './commands/randomcabin.command';
+import SubscribeCommand from './commands/subscribe.command';
 import { BaseCommand } from './slashCommand.interface';
 
 @Injectable()
@@ -19,11 +21,13 @@ export class SlashCommandService implements OnModuleInit {
     private readonly chatCommandService: ChatCommandService,
     private readonly embedService: EmbedService,
     private readonly cabinService: CabinService,
+    private readonly subscriptionService: SubscriptionService,
   ) {
     this.slashCommands = [
       new PingCommand(),
       new PspspsCommand(),
       new RandomCabinCommand(this.cabinService, this.embedService),
+      new SubscribeCommand(this.subscriptionService),
     ];
   }
 

--- a/src/subscription/subscription.module.ts
+++ b/src/subscription/subscription.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DbModule } from 'src/db/db.module';
+import { SubscriptionService } from './subscription.service';
+
+@Module({
+  imports: [DbModule],
+  providers: [SubscriptionService],
+  exports: [SubscriptionService],
+})
+export class SubscriptionModule {}

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -1,12 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { DbService } from 'src/db/db.service';
-
-interface Subscription {
-  subscriberId: string;
-  subscriberType: string;
-  type: string;
-  topic: string | null;
-}
 
 @Injectable()
 export class SubscriptionService {
@@ -14,7 +8,7 @@ export class SubscriptionService {
 
   constructor(private readonly dbService: DbService) {}
 
-  public async add(subscription: Subscription) {
+  public async add(subscription: Prisma.subscriptionsCreateInput) {
     try {
       await this.dbService.prisma.subscriptions.create({
         data: subscription,

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DbService } from 'src/db/db.service';
+
+interface Subscription {
+  subscriberId: string;
+  subscriberType: string;
+  type: string;
+  topic: string | null;
+}
+
+@Injectable()
+export class SubscriptionService {
+  private readonly logger = new Logger(SubscriptionService.name);
+
+  constructor(private readonly dbService: DbService) {}
+
+  public async add(subscription: Subscription) {
+    try {
+      await this.dbService.prisma.subscriptions.create({
+        data: subscription,
+      });
+    } catch (error) {
+      this.logger.log(
+        'Adding new subscription to database failed with error',
+        error,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  public async getActivities(tripType: string, after: Date) {
+    return this.dbService.prisma.activities.findMany({
+      where: {
+        tripType: { has: tripType },
+        createdAt: { gt: after },
+      },
+    });
+  }
+}


### PR DESCRIPTION
This is the first iteration of a new feature, the subscription service, where users and channels can subscribe to topics to receive daily notifications.

This PR contains the subscription process via the "subscribe" slash command that then saves a new subscription in the database.